### PR TITLE
Version Bump + Small Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ## Background Tips package
-[![OS X Build Status](https://travis-ci.org/atom/background-tips.svg?branch=master)](https://travis-ci.org/atom/background-tips) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/2utcugietl5vjc7w/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/background-tips/branch/master) [![Dependency Status](https://david-dm.org/atom/background-tips.svg)](https://david-dm.org/atom/background-tips)
 
 Displays tips about Pulsar in the background when there are no open editors.
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "background-tips",
   "main": "./lib/background-tips",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "private": true,
   "description": "Displays tips about Pulsar in the background when there are no editors open.",
-  "repository": "https://github.com/atom/background-tips",
+  "repository": "https://github.com/pulsar-edit/background-tips",
   "license": "MIT",
   "engines": {
     "atom": ">0.42.0"


### PR DESCRIPTION
This PR bumps the version of `background-tips` as well as addresses some small issues, such as fixing the Repository Link in `package.json` and removed outdated CI links/badges on the `README.md`.

Otherwise this bumps `background-tips` to version `0.28.1` from `0.28.0`. If this PR is accepted I'll create a tagged release from this version, that we can start using within the main Editor.

This will allow changes from other contributors to be available on the main editor. 

While the changes aren't significant it seems likely that it will be all that's needed for the near future.