### PR TITLE
use generic name

### DIFF
--- a/lib/tips.js
+++ b/lib/tips.js
@@ -1,6 +1,6 @@
 module.exports = [
   'Close panels like find and replace with {body>core:cancel}',
-  'Everything Pulsar can do is in the Command Palette. See it by using {command-palette:toggle}',
+  `Everything ${atom.branding.name} can do is in the Command Palette. See it by using {command-palette:toggle}`,
   'You can quickly open files with the Fuzzy Finder. Try it by using {fuzzy-finder:toggle-file-finder}',
   'You can toggle the Tree View with {tree-view:toggle}',
   'You can focus the Tree View with {tree-view:toggle-focus}',


### PR DESCRIPTION
This replaces the fixed IDE name with the generic `atom.branding.name` variable.